### PR TITLE
Long press encoder button toggles relay state

### DIFF
--- a/app/apps/app_power_monitor/view/view_single_data.cpp
+++ b/app/apps/app_power_monitor/view/view_single_data.cpp
@@ -90,6 +90,11 @@ void PmDataPage::update(uint32_t currentTime)
             _render();
         }
 
+        if (Button::Encoder()->wasHold())
+        {
+            HAL::SetBaseRelay(!HAL::GetBaseRelayState());
+        }
+
         // Check quit
         if (Button::Side()->wasHold())
         {

--- a/app/apps/app_waveform/view/recorder.cpp
+++ b/app/apps/app_waveform/view/recorder.cpp
@@ -69,6 +69,11 @@ void WaveFormRecorder::update()
         break;
     }
 
+    if (Button::Encoder()->wasHold())
+    {
+      HAL::SetBaseRelay(!HAL::GetBaseRelayState());
+    }
+
     // Check quit
     if (Button::Side()->wasHold())
         _data.want_to_quit = true;


### PR DESCRIPTION
when in PowerMonitor screens and in Waveform screen.