### PR TITLE
fix: Add copy constructor deletion to prevent potential double-free

### DIFF
--- a/app/apps/app_power_monitor/app_power_monitor.h
+++ b/app/apps/app_power_monitor/app_power_monitor.h
@@ -36,6 +36,12 @@ namespace MOONCAKE
             void _setup_page_more_detail();
 
         public:
+            // Default constructor
+            AppPower_monitor() = default;
+            // Delete copy constructor and assignment operator to prevent double-free
+            AppPower_monitor(const AppPower_monitor&) = delete;
+            AppPower_monitor& operator=(const AppPower_monitor&) = delete;
+
             void onResume() override;
             void onRunning() override;
             void onDestroy() override;

--- a/app/apps/app_waveform/app_waveform.h
+++ b/app/apps/app_waveform/app_waveform.h
@@ -25,6 +25,12 @@ namespace MOONCAKE
             void _handle_recording_finished();
 
         public:
+            // Default constructor
+            AppWaveform() = default;
+            // Delete copy constructor and assignment operator to prevent double-free
+            AppWaveform(const AppWaveform&) = delete;
+            AppWaveform& operator=(const AppWaveform&) = delete;
+
             void onResume() override;
             void onRunning() override;
             void onDestroy() override;


### PR DESCRIPTION
## Summary
🎉 **HAPPY NEW YEAR from Japan!** 🎉
This PR adds explicit copy constructor and assignment operator deletion to AppPower_monitor and AppWaveform classes to prevent potential double-free issues.
## Problem
Both classes contain raw pointer members:
- AppPower_monitor: `VIEWS::PmDataPage* view`
- AppWaveform: `VIEWS::WaveFormRecorder* view`
If these objects are copied (either via copy constructor or assignment), both the original and the copy would hold the same pointer. When their destructors run, the same memory would be freed twice, causing undefined behavior (double-free).
## Solution
Apply the "Rule of Five" pattern by explicitly deleting copy operations:
```cpp
// Default constructor
AppPower_monitor() = default;
// Delete copy constructor and assignment operator to prevent double-free
AppPower_monitor(const AppPower_monitor&) = delete;
AppPower_monitor& operator=(const AppPower_monitor&) = delete;
```
The same pattern is applied to AppWaveform.

## Notes
The Mooncake framework currently manages app lifecycle in a way that prevents copying, so this is a preventive fix, not a bug fix for an observed issue.
Adding = default for the default constructor is required because declaring any constructor (including deleted ones) suppresses the implicit default constructor.
No behavioral changes to existing functionality.
## Testing
Compiled and tested on ESP-IDF 5.1.3
Verified app creation via newApp() still works correctly